### PR TITLE
refactor swing hook mech to utilize physics-based circular motion

### DIFF
--- a/scripts/player/player_movement.gd
+++ b/scripts/player/player_movement.gd
@@ -18,10 +18,10 @@ func process_movement(player, delta):
 				player.jump_state = 0
 			if GameInputMapper.is_action_pressed("move_right"):
 				player.velocity.x = player.speed
-				#player.set_deferred("rotation", 0)
+				player.set_deferred("rotation", 0)
 			if GameInputMapper.is_action_pressed("move_left"):
 				player.velocity.x = -player.speed
-				#player.set_deferred("rotation", -PI)
+				player.set_deferred("rotation", -PI)
 		player.State.JUST_HOOKED:
 			player.change_state(player.State.HOOKING)
 		player.State.SWING:


### PR DESCRIPTION
- Resolved the issue where the player does not fall down when positioned above the hook point.
- Modified the hook mechanic to apply acceleration in a standard manner.
- Implemented logic to project speed only perpendicular to the hook direction if the speed tries to extend beyond the hook length.

Note: Hook length may become longer over time due to discreate movement calculations. (shouldn't affect gameplay experience)